### PR TITLE
Added a docker.sh script which builds the driver using the same version of libstdc++ as steamvr!

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,20 @@ Don't forget to make a backup if you have special SteamVR settings.
 
 Now run SteamVR and check ~/.local/share/Steam/logs/vrserver.txt for errors.
 
+
+## Build with docker:
+
+    git clone --recursive https://github.com/ChristophHaag/SteamVR-OpenHMD.git
+    cd SteamVR-OpenHMD
+    docker.sh
+
+This will create a docker container running the same GCC as Steam uses, so the driver will be compatible with Steam runtime libstdc++ librarie.
+The script docker.sh will create the container, build the driver, register it with steam (using `vrpathreg adddriver` as described above) and, if the build is successful, it launches steamVR using STEAM_RUNTIME_PREFER_HOST_LIBRARIES=0 so Steam uses it's own runtime environment to run steamVR.
+
+This method is simpler to build the driver and builds a driver fully compatible with the steam runtime, no matter the distro you're running.
+
+
+
 ## Configuration:
 
 Upstream pull request to follow: https://github.com/OpenHMD/OpenHMD/issues/8

--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ Now run SteamVR and check ~/.local/share/Steam/logs/vrserver.txt for errors.
 This will create a docker container running the same GCC as Steam uses, so the driver will be compatible with Steam runtime libstdc++ library.
 The script docker.sh will create the container, build the driver, register it with steam (using `vrpathreg adddriver` as described above) and, if the build is successful, it launches steamVR using STEAM_RUNTIME_PREFER_HOST_LIBRARIES=0 so Steam uses it's own runtime environment to run steamVR.
 
-This method is simpler to build the driver and builds a driver fully compatible with the steam runtime, no matter the distro you're running.
+This method is simpler to build the driver and builds a driver fully compatible with the steam runtime, no matter the distro you're running. You just need to have Docker installed!
 
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -30,13 +30,13 @@ Don't forget to make a backup if you have special SteamVR settings.
 Now run SteamVR and check ~/.local/share/Steam/logs/vrserver.txt for errors.
 
 
-## Build with docker:
+## Build and run with docker:
 
     git clone --recursive https://github.com/ChristophHaag/SteamVR-OpenHMD.git
     cd SteamVR-OpenHMD
     docker.sh
 
-This will create a docker container running the same GCC as Steam uses, so the driver will be compatible with Steam runtime libstdc++ librarie.
+This will create a docker container running the same GCC as Steam uses, so the driver will be compatible with Steam runtime libstdc++ library.
 The script docker.sh will create the container, build the driver, register it with steam (using `vrpathreg adddriver` as described above) and, if the build is successful, it launches steamVR using STEAM_RUNTIME_PREFER_HOST_LIBRARIES=0 so Steam uses it's own runtime environment to run steamVR.
 
 This method is simpler to build the driver and builds a driver fully compatible with the steam runtime, no matter the distro you're running.

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+CD=$(dirname $BASH_SOURCE)
+
+cd $CD
+CD=$(pwd)
+cd $CD/docker
+
+#docker-compose up --build
+docker build ./ -t steamvr_openhmd/build
+
+docker run -ti --rm \
+    -e USER=$USER \
+    -v $HOME:/home/$USER \
+    -v $CD:/tmp/dev/ \
+    -v /etc/passwd:/etc/passwd \
+    --name build \
+steamvr_openhmd/build:latest "$@"
+
+
+~/.local/share/Steam/steamapps/common/SteamVR/bin/linux64/vrpathreg adddriver $CD/build/
+
+
+export STEAM_RUNTIME_PREFER_HOST_LIBRARIES=0
+
+~/.local/share/Steam/ubuntu12_32/steam-runtime/run.sh ~/.local/share/Steam/steamapps/common/SteamVR/bin/vrstartup.sh

--- a/docker.sh
+++ b/docker.sh
@@ -8,7 +8,6 @@ cd $CD/docker
 
 #docker-compose up --build
 docker build ./ -t steamvr_openhmd/build
-
 docker run -ti --rm \
     -e USER=$USER \
     -v $HOME:/home/$USER \
@@ -18,9 +17,10 @@ docker run -ti --rm \
 steamvr_openhmd/build:latest "$@"
 
 
+# register this build with steamVR automatically
 ~/.local/share/Steam/steamapps/common/SteamVR/bin/linux64/vrpathreg adddriver $CD/build/
 
 
+# run steamVR, giving priority to Steam runtime libraries instead of system libraries.
 export STEAM_RUNTIME_PREFER_HOST_LIBRARIES=0
-
 ~/.local/share/Steam/ubuntu12_32/steam-runtime/run.sh ~/.local/share/Steam/steamapps/common/SteamVR/bin/vrstartup.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM walberla/buildenv-ubuntu-basic:16.04
+
+MAINTAINER hradec <hradec@hradec.com>
+
+ARG GCC_VERSION=4.9
+
+RUN apt-get update 
+
+RUN  apt-get install  -y \
+    gcc-$GCC_VERSION \
+    g++-$GCC_VERSION \
+    nano \
+    sudo \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* 
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 999 \
+ && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$GCC_VERSION 999 \
+ && update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-$GCC_VERSION 999 \
+ && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-$GCC_VERSION 999
+
+ENV CC="ccache gcc" CXX="ccache g++" 
+
+ENV USER=testuser
+
+
+RUN echo '#!/bin/bash' > /run.sh ; \
+    echo 'runuser - $USER -c "cd /tmp/dev && mkdir build && cd build && cmake ../ && make"' >> /run.sh ; \
+    chmod a+x /run.sh ; \
+    cp /run.sh /start.sh
+
+CMD ["/start.sh"]
+
+
+
+
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,34 +4,25 @@ MAINTAINER hradec <hradec@hradec.com>
 
 ARG GCC_VERSION=4.9
 
-RUN apt-get update 
+RUN apt-get update
 
 RUN  apt-get install  -y \
     gcc-$GCC_VERSION \
     g++-$GCC_VERSION \
+    libhidapi-dev \
+    libhidapi-libusb0 \
     nano \
-    sudo \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* 
+    sudo
 
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$GCC_VERSION 999 \
  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$GCC_VERSION 999 \
  && update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-$GCC_VERSION 999 \
  && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-$GCC_VERSION 999
 
-ENV CC="ccache gcc" CXX="ccache g++" 
+ENV CC="ccache gcc" CXX="ccache g++ -std=c++11"
 
 ENV USER=testuser
 
-
-RUN echo '#!/bin/bash' > /run.sh ; \
-    echo 'runuser - $USER -c "cd /tmp/dev && mkdir build && cd build && cmake ../ && make"' >> /run.sh ; \
-    chmod a+x /run.sh ; \
-    cp /run.sh /start.sh
+ADD start.sh /
 
 CMD ["/start.sh"]
-
-
-
-
-

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,8 @@
+steamvr_openhmd_build:
+  build:  .
+  volumes:
+    - $HOME:/home/$USER/
+    - ../:/tmp/dev/
+    - /etc/passwd:/etc/passwd
+  environment:
+    USER : $USER

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+
+mkdir -p /tmp/dev/build
+
+cd /tmp/dev/build
+
+runuser -c 'cmake ../ && make'
+
+echo "All Build Suscessfully!"


### PR DESCRIPTION
docker.sh create a docker container with Ubuntu 16.04 and everything needed to build SteamVR-OpenHMD. 

This method makes the driver works with STEAM_RUNTIME_PREFER_HOST_LIBRARIES=0 environment var, which essentially forces Steam to use it's own libraries instead of the system one.

In this case, we must build the driver with the same GCC used to build SteamVR, or else the driver will fail to load! (so the driver can work with steam runtime libstdc++)

More information can be found here: https://github.com/ValveSoftware/steam-for-linux/issues/4475
(search for "STEAM_RUNTIME_PREFER_HOST_LIBRARIES:")