### PR TITLE
Removed ' characters from the example udev rules

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -124,27 +124,27 @@ Add a file named `83-hmd.rules` to `/etc/udev/rules.d/`, or your distributions e
 As an example the content of this file could look like this:
 
     #Oculus DK1 DK2 CV1
-    SUBSYSTEM=="usb", ATTR{idVendor}=="2833", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="2833", MODE="0666", GROUP="plugdev"
     #Vive
-    SUBSYSTEM=="usb", ATTR{idVendor}=="0bb4", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0bb4", MODE="0666", GROUP="plugdev"
     #Deepoon
-    SUBSYSTEM=="usb", ATTR{idVendor}=="0483", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0483", MODE="0666", GROUP="plugdev"
     #Sony PSVR
-    SUBSYSTEM=="usb", ATTR{idVendor}=="054c", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="054c", MODE="0666", GROUP="plugdev"
     #OSVR
-    SUBSYSTEM=="usb", ATTR{idVendor}=="1532", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="1532", MODE="0666", GROUP="plugdev"
     #Pimax 4K
-    SUBSYSTEM=="usb", ATTR{idVendor}=="2833", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="2833", MODE="0666", GROUP="plugdev"
     #NOLO CV1
-    SUBSYSTEM=="usb", ATTR{idVendor}=="0483", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0483", MODE="0666", GROUP="plugdev"
     #Samsung GearVR
-    SUBSYSTEM=="usb", ATTR{idVendor}=="04E8", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="04E8", MODE="0666", GROUP="plugdev"
     #HP Mixed Reality
-    SUBSYSTEM=="usb", ATTR{idVendor}=="03F0", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="03F0", MODE="0666", GROUP="plugdev"
     #Lenovo Mixed Reality
-    SUBSYSTEM=="usb", ATTR{idVendor}=="045e", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="045e", MODE="0666", GROUP="plugdev"
     #DreamWorld DreamGlass AR
-    SUBSYSTEM=="usb", ATTR{idVendor}=="0483", MODE="0666", GROUP="plugdev"'
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0483", MODE="0666", GROUP="plugdev"
 
 
 ## License


### PR DESCRIPTION
systemd-udevd complains about these characters and I think they were just a typo on my end.