### PR TITLE
Fixes incorrect  file location in install_files_to_build.sh

### DIFF
--- a/install_files_to_build.sh
+++ b/install_files_to_build.sh
@@ -5,7 +5,7 @@ cp -r resources build/
 
 mkdir -p build/bin/{win64,win32,osx64,osx32,linux64,linux32}
 
-rm -f build/bin/linux64/driver_openhmd.so && cp build/driver_openhmd.so build/bin/linux64 2> /dev/null && \
+rm -f build/bin/linux64/driver_openhmd.so && cp build/driver_openhmd.so build/bin/linux64/driver_openhmd.so 2> /dev/null && \
   echo "Installed linux plugin!" || echo "Did not install linux plugin!"
 
-rm -f build/bin/win64/driver_openhmnd.so && cp build/driver_openhmd.dll build/bin/win64 2> /dev/null && echo "Installed windows plugin!" || echo "Did not install windows plugin!"
+rm -f build/bin/win64/driver_openhmnd.so && cp build/driver_openhmd.dll build/bin/win64/driver_openhmd.dll 2> /dev/null && echo "Installed windows plugin!" || echo "Did not install windows plugin!"


### PR DESCRIPTION
Originally moved driver_openhmd.so to /bin/ and renamed to linux64 instead of moving it to /bin/linux64/
should fix same problem with windows build