### PR TITLE
Refactor config and disable autodetect if the config is provided

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -135,6 +135,8 @@ This defines 4 openhmd devices.
 
 If the config file is not available (probably only works on linux), default values are used. Change them in ohmd_config.h.
 
+There is also the option `autodetect 1` which enables autodetection (enabled if you have no config file, and normally disabled if you have a config file). Disabling autodetection is important because you may or may not wish the OpenHMD "null" controllers to be present.
+
 ### Gaze Pointer with gamepad
 
 At least SteamVR Home supports controller based navigation, however it is only enabled when the Manufacturer string provided by the plugin is "Oculus".

--- a/driver_openhmd.cpp
+++ b/driver_openhmd.cpp
@@ -1066,10 +1066,9 @@ EVRInitError CServerDriver_OpenHMD::Init( vr::IVRDriverContext *pDriverContext )
         DriverLog("failed to probe devices: %s\n", ohmd_ctx_get_error(ctx));
     }
 
-    int hmddisplay_idx = get_configvalues()[0];
-    int hmdtracker_idx = get_configvalues()[1];
-    int lcontroller_idx = get_configvalues()[2];
-    int rcontroller_idx = get_configvalues()[3];
+    configvalues_t cfg = {1, -1, -1, -1, -1};
+
+    get_configvalues(&cfg);
 
     for(int i = 0; i < num_devices; i++){
         DriverLog("device %d\n", i);
@@ -1082,50 +1081,52 @@ EVRInitError CServerDriver_OpenHMD::Init( vr::IVRDriverContext *pDriverContext )
         ohmd_list_geti(ctx, i, OHMD_DEVICE_CLASS, &device_class);
         ohmd_list_geti(ctx, i, OHMD_DEVICE_FLAGS, &device_flags);
 
-	switch (device_class) {
-		case OHMD_DEVICE_CLASS_HMD:
-			if (hmddisplay_idx == -1)
-				hmddisplay_idx = i;
-			break;
-		case OHMD_DEVICE_CLASS_CONTROLLER:
-			if (lcontroller_idx == -1 && (device_flags & OHMD_DEVICE_FLAGS_LEFT_CONTROLLER))
-				lcontroller_idx = i;
-			else if (rcontroller_idx == -1 && (device_flags & OHMD_DEVICE_FLAGS_RIGHT_CONTROLLER))
-				rcontroller_idx = i;
-			break;
-		case OHMD_DEVICE_CLASS_GENERIC_TRACKER:
-			if (hmdtracker_idx == -1 && !(device_flags & (OHMD_DEVICE_FLAGS_LEFT_CONTROLLER|OHMD_DEVICE_FLAGS_RIGHT_CONTROLLER)))
-				hmdtracker_idx = i;
-			else if (lcontroller_idx == -1 && (device_flags & OHMD_DEVICE_FLAGS_LEFT_CONTROLLER))
-				lcontroller_idx = i;
-			else if (rcontroller_idx == -1 && (device_flags & OHMD_DEVICE_FLAGS_RIGHT_CONTROLLER))
-				rcontroller_idx = i;
-			break;
-		default:
-			break;
-	}
+        if (cfg.autodetect) {
+            switch (device_class) {
+                case OHMD_DEVICE_CLASS_HMD:
+                if (cfg.hmddisplay_idx == -1)
+                    cfg.hmddisplay_idx = i;
+                break;
+            case OHMD_DEVICE_CLASS_CONTROLLER:
+                if (cfg.lcontroller_idx == -1 && (device_flags & OHMD_DEVICE_FLAGS_LEFT_CONTROLLER))
+                    cfg.lcontroller_idx = i;
+                else if (cfg.rcontroller_idx == -1 && (device_flags & OHMD_DEVICE_FLAGS_RIGHT_CONTROLLER))
+                    cfg.rcontroller_idx = i;
+                break;
+            case OHMD_DEVICE_CLASS_GENERIC_TRACKER:
+                if (cfg.hmdtracker_idx == -1 && !(device_flags & (OHMD_DEVICE_FLAGS_LEFT_CONTROLLER|OHMD_DEVICE_FLAGS_RIGHT_CONTROLLER)))
+                    cfg.hmdtracker_idx = i;
+                else if (cfg.lcontroller_idx == -1 && (device_flags & OHMD_DEVICE_FLAGS_LEFT_CONTROLLER))
+                    cfg.lcontroller_idx = i;
+                else if (cfg.rcontroller_idx == -1 && (device_flags & OHMD_DEVICE_FLAGS_RIGHT_CONTROLLER))
+                    cfg.rcontroller_idx = i;
+                break;
+            default:
+                break;
+            }
+        }
     }
 
-    if (hmdtracker_idx == -1)
-    	hmdtracker_idx = hmddisplay_idx;
+    if (cfg.hmdtracker_idx == -1)
+    	cfg.hmdtracker_idx = cfg.hmddisplay_idx;
 
-    DriverLog("Using HMD Display %d, HMD Tracker %d, Left Controller %d, Right Controller %d\n", hmddisplay_idx, hmdtracker_idx, lcontroller_idx, rcontroller_idx);
+    DriverLog("Using HMD Display %d, HMD Tracker %d, Left Controller %d, Right Controller %d\n", cfg.hmddisplay_idx, cfg.hmdtracker_idx, cfg.lcontroller_idx, cfg.rcontroller_idx);
 
-    m_OpenHMDDeviceDriver = new COpenHMDDeviceDriver(hmddisplay_idx, hmdtracker_idx);
+    m_OpenHMDDeviceDriver = new COpenHMDDeviceDriver(cfg.hmddisplay_idx, cfg.hmdtracker_idx);
     vr::VRServerDriverHost()->TrackedDeviceAdded( m_OpenHMDDeviceDriver->GetSerialNumber().c_str(), vr::TrackedDeviceClass_HMD, m_OpenHMDDeviceDriver );
 
-    if (lcontroller_idx >= 0) {
-	ohmd_device* lcontroller = ohmd_list_open_device(ctx, lcontroller_idx);
+    if (cfg.lcontroller_idx >= 0) {
+	ohmd_device* lcontroller = ohmd_list_open_device(ctx, cfg.lcontroller_idx);
 	if (lcontroller)
-		m_OpenHMDDeviceDriverControllerL = new COpenHMDDeviceDriverController(0, lcontroller, lcontroller_idx);
+		m_OpenHMDDeviceDriverControllerL = new COpenHMDDeviceDriverController(0, lcontroller, cfg.lcontroller_idx);
 	if (m_OpenHMDDeviceDriverControllerL)
 		vr::VRServerDriverHost()->TrackedDeviceAdded( m_OpenHMDDeviceDriverControllerL->GetSerialNumber().c_str(), vr::TrackedDeviceClass_Controller, m_OpenHMDDeviceDriverControllerL );
     }
 
-    if (rcontroller_idx >= 0) {
-	ohmd_device *rcontroller = ohmd_list_open_device(ctx, rcontroller_idx);
+    if (cfg.rcontroller_idx >= 0) {
+	ohmd_device *rcontroller = ohmd_list_open_device(ctx, cfg.rcontroller_idx);
 	if (rcontroller)
-		m_OpenHMDDeviceDriverControllerR = new COpenHMDDeviceDriverController(1, rcontroller, rcontroller_idx);
+		m_OpenHMDDeviceDriverControllerR = new COpenHMDDeviceDriverController(1, rcontroller, cfg.rcontroller_idx);
 	if (m_OpenHMDDeviceDriverControllerR)
 		vr::VRServerDriverHost()->TrackedDeviceAdded(  m_OpenHMDDeviceDriverControllerR->GetSerialNumber().c_str(), vr::TrackedDeviceClass_Controller, m_OpenHMDDeviceDriverControllerR );
     }

--- a/ohmd_config.h
+++ b/ohmd_config.h
@@ -3,10 +3,16 @@
 #include <string.h>
 #include "driverlog.h"
 
-/** returns hmddisplay, hmdtracker, leftcontroller, rightcontroller */
-int *get_configvalues() {
-    int *vals = (int*) malloc(4*sizeof(int));
+typedef struct {
+    int autodetect;
+    int hmddisplay_idx;
+    int hmdtracker_idx;
+    int lcontroller_idx;
+    int rcontroller_idx;
+} configvalues_t;
 
+/** returns hmddisplay, hmdtracker, leftcontroller, rightcontroller */
+void get_configvalues(configvalues_t *cfg) {
     char *home = getenv("HOME");
     char filename[255];
     sprintf(filename, "%s/%s", home, ".ohmd_config.txt");
@@ -14,32 +20,32 @@ int *get_configvalues() {
     if (file) {
         DriverLog("opened config file %s\n", filename);
         char line[256];
+        cfg->autodetect = 0;
 
         while (fgets(line, sizeof(line), file)) {
             char* option = strtok(line, " ");
             char* value = strtok(NULL, " ");
             //printf("%s: %s\n", option, value);
+            if (strcmp(option, "autodetect") == 0) {
+                cfg->autodetect = strtol(value, NULL, 10);
+            }
             if (strcmp(option, "hmddisplay") == 0) {
-                vals[0] = strtol(value, NULL, 10);
+                cfg->hmddisplay_idx = strtol(value, NULL, 10);
             }
             if (strcmp(option, "hmdtracker") == 0) {
-                vals[1] = strtol(value, NULL, 10);
+                cfg->hmdtracker_idx = strtol(value, NULL, 10);
             }
             if (strcmp(option, "leftcontroller") == 0) {
-                vals[2] = strtol(value, NULL, 10);
+                cfg->lcontroller_idx = strtol(value, NULL, 10);
             }
             if (strcmp(option, "rightcontroller") == 0) {
-                vals[3] = strtol(value, NULL, 10);
+                cfg->rcontroller_idx = strtol(value, NULL, 10);
             }
         }
         fclose(file);
         
     } else {
         DriverLog("could not open config file %s, using default headset 0 with no controller\n", filename);
-        vals[0] = 0;
-        vals[1] = 0;
-        vals[2] = -1;
-        vals[3] = -1;
     }
-    return vals;
 }
+


### PR DESCRIPTION
So something I've run into with my personal setup is that if you have an HMD via OpenHMD, but no controllers, OpenHMD's "null" drivers tend to occupy the left/right controller slots.

However, for some circumstances (i.e. confirming function of the driver), using the null drivers is wanted, so ignoring them is not advisible.

Owing to this, I've modified how the config is handled. Autodetection is now disabled if an explicit config file is provided, and there are now proper default values rather than uninitialized memory.
